### PR TITLE
chore: upgrade to Go 1.26 and update tooling/dependencies

### DIFF
--- a/.github/actions/install-task/action.yml
+++ b/.github/actions/install-task/action.yml
@@ -15,8 +15,7 @@ runs:
       run: |
         set -euo pipefail
         TASK_VERSION="${{ inputs.task-version }}"
-        TASK_VERSION_NO_V="${TASK_VERSION#v}"
-        TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
+        TASK_ARCHIVE="task_linux_amd64.tar.gz"
 
         curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
         tar xzf "${TASK_ARCHIVE}"

--- a/.github/actions/install-task/action.yml
+++ b/.github/actions/install-task/action.yml
@@ -1,0 +1,23 @@
+name: Install Task
+
+description: Install a pinned go-task binary on Linux runners
+
+inputs:
+  task-version:
+    description: Task version with leading v (for example v3.48.0)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install task binary
+      shell: bash
+      run: |
+        set -euo pipefail
+        TASK_VERSION="${{ inputs.task-version }}"
+        TASK_VERSION_NO_V="${TASK_VERSION#v}"
+        TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
+
+        curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
+        tar xzf "${TASK_ARCHIVE}"
+        sudo mv task /usr/local/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.25.7"
-  GORELEASER_VERSION: "v2.4.0"
-  TASK_VERSION: "latest"
+  GO_VERSION: "1.26.0"
+  GORELEASER_VERSION: "v2.14.0"
+  TASK_VERSION: "v3.48.0"
 
 jobs:
   # Quality Gates
@@ -38,7 +38,12 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: curl -fsSLO https://github.com/go-task/task/releases/download/v3.42.0/task_linux_amd64.tar.gz && tar xzf task_linux_amd64.tar.gz && sudo mv task /usr/local/bin/
+        run: |
+          TASK_VERSION_NO_V="${TASK_VERSION#v}"
+          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
+          tar xzf "${TASK_ARCHIVE}"
+          sudo mv task /usr/local/bin/
 
       - name: Run CI Quality Checks
         run: task ci-quality
@@ -49,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.25.7"]
+        go-version: ["1.26.0"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -61,7 +66,12 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: curl -fsSLO https://github.com/go-task/task/releases/download/v3.42.0/task_linux_amd64.tar.gz && tar xzf task_linux_amd64.tar.gz && sudo mv task /usr/local/bin/
+        run: |
+          TASK_VERSION_NO_V="${TASK_VERSION#v}"
+          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
+          tar xzf "${TASK_ARCHIVE}"
+          sudo mv task /usr/local/bin/
 
       - name: Run CI Tests
         run: task ci-test
@@ -92,7 +102,12 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: curl -fsSLO https://github.com/go-task/task/releases/download/v3.42.0/task_linux_amd64.tar.gz && tar xzf task_linux_amd64.tar.gz && sudo mv task /usr/local/bin/
+        run: |
+          TASK_VERSION_NO_V="${TASK_VERSION#v}"
+          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
+          tar xzf "${TASK_ARCHIVE}"
+          sudo mv task /usr/local/bin/
 
       - name: Run CI Build
         run: task ci-build
@@ -118,7 +133,12 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: curl -fsSLO https://github.com/go-task/task/releases/download/v3.42.0/task_linux_amd64.tar.gz && tar xzf task_linux_amd64.tar.gz && sudo mv task /usr/local/bin/
+        run: |
+          TASK_VERSION_NO_V="${TASK_VERSION#v}"
+          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
+          tar xzf "${TASK_ARCHIVE}"
+          sudo mv task /usr/local/bin/
 
       - name: Run CI Release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,9 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: |
-          TASK_VERSION_NO_V="${TASK_VERSION#v}"
-          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
-          tar xzf "${TASK_ARCHIVE}"
-          sudo mv task /usr/local/bin/
+        uses: ./.github/actions/install-task
+        with:
+          task-version: ${{ env.TASK_VERSION }}
 
       - name: Run CI Quality Checks
         run: task ci-quality
@@ -66,12 +63,9 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: |
-          TASK_VERSION_NO_V="${TASK_VERSION#v}"
-          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
-          tar xzf "${TASK_ARCHIVE}"
-          sudo mv task /usr/local/bin/
+        uses: ./.github/actions/install-task
+        with:
+          task-version: ${{ env.TASK_VERSION }}
 
       - name: Run CI Tests
         run: task ci-test
@@ -102,12 +96,9 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: |
-          TASK_VERSION_NO_V="${TASK_VERSION#v}"
-          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
-          tar xzf "${TASK_ARCHIVE}"
-          sudo mv task /usr/local/bin/
+        uses: ./.github/actions/install-task
+        with:
+          task-version: ${{ env.TASK_VERSION }}
 
       - name: Run CI Build
         run: task ci-build
@@ -133,12 +124,9 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: |
-          TASK_VERSION_NO_V="${TASK_VERSION#v}"
-          TASK_ARCHIVE="task_${TASK_VERSION_NO_V}_linux_amd64.tar.gz"
-          curl -fsSLO "https://github.com/go-task/task/releases/download/${TASK_VERSION}/${TASK_ARCHIVE}"
-          tar xzf "${TASK_ARCHIVE}"
-          sudo mv task /usr/local/bin/
+        uses: ./.github/actions/install-task
+        with:
+          task-version: ${{ env.TASK_VERSION }}
 
       - name: Run CI Release
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 # Run configuration
 run:
   timeout: 5m
-  go: "1.25"
+  go: "1.26"
   tests: true
   allow-parallel-runners: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ This project adheres to a code of conduct. By participating, you are expected to
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.26 or later
 - Make
 - Git
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CVEWatch provides real-time vulnerability monitoring using the official National
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.26 or later
 - Internet connection for NVD API access
 - NVD API key (optional, but recommended for higher rate limits)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,15 @@ vars:
   GORELEASER_VERSION: v2.14.0
 
 tasks:
+  _run-go-tool:
+    internal: true
+    cmds:
+      - |
+        GOBIN_DIR="$(go env GOPATH)/bin"
+        echo "Installing {{.TOOL_NAME}}..."
+        GOTOOLCHAIN=go1.26.0 go install {{.TOOL_PACKAGE}}
+        "${GOBIN_DIR}/{{.TOOL_BIN}}" {{.TOOL_ARGS}}
+
   default:
     desc: Show available tasks
     cmds:
@@ -107,11 +116,12 @@ tasks:
     cmds:
       - echo "Formatting code..."
       - go fmt ./...
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing goimports..."
-        GOTOOLCHAIN=go1.26.0 go install golang.org/x/tools/cmd/goimports@v0.42.0
-        "${GOBIN_DIR}/goimports" -w .
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: goimports
+          TOOL_PACKAGE: golang.org/x/tools/cmd/goimports@v0.42.0
+          TOOL_BIN: goimports
+          TOOL_ARGS: -w .
 
   check-fmt:
     desc: Check if code is properly formatted
@@ -129,32 +139,35 @@ tasks:
     desc: Run linters (golangci-lint v2)
     cmds:
       - echo "Running linters..."
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing golangci-lint..."
-        GOTOOLCHAIN=go1.26.0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
-        "${GOBIN_DIR}/golangci-lint" run
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: golangci-lint
+          TOOL_PACKAGE: github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+          TOOL_BIN: golangci-lint
+          TOOL_ARGS: run
 
   security-scan:
     desc: Run security scanner (gosec)
     cmds:
       - echo "Running security scan..."
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing gosec..."
-        GOTOOLCHAIN=go1.26.0 go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
-        "${GOBIN_DIR}/gosec" -fmt=json -out=security-report.json -severity=medium -confidence=medium ./...
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: gosec
+          TOOL_PACKAGE: github.com/securego/gosec/v2/cmd/gosec@v2.23.0
+          TOOL_BIN: gosec
+          TOOL_ARGS: -fmt=json -out=security-report.json -severity=medium -confidence=medium ./...
       - echo "Security scan completed. Report saved to security-report.json"
 
   vuln-check:
     desc: Run Go vulnerability database check (govulncheck)
     cmds:
       - echo "Running govulncheck..."
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing govulncheck..."
-        GOTOOLCHAIN=go1.26.0 go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-        "${GOBIN_DIR}/govulncheck" ./...
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: govulncheck
+          TOOL_PACKAGE: golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          TOOL_BIN: govulncheck
+          TOOL_ARGS: ./...
       - echo "Vulnerability check completed."
 
   # Installation
@@ -210,31 +223,34 @@ tasks:
       - echo "Creating release with GoReleaser..."
       - git checkout -- .
       - git clean -fd
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing GoReleaser..."
-        GOTOOLCHAIN=go1.26.0 go install github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
-        "${GOBIN_DIR}/goreleaser" release --clean
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: GoReleaser
+          TOOL_PACKAGE: github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
+          TOOL_BIN: goreleaser
+          TOOL_ARGS: release --clean
 
   release-snapshot:
     desc: Create snapshot release (for testing)
     cmds:
       - echo "Creating snapshot release..."
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing GoReleaser..."
-        GOTOOLCHAIN=go1.26.0 go install github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
-        "${GOBIN_DIR}/goreleaser" release --snapshot --clean
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: GoReleaser
+          TOOL_PACKAGE: github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
+          TOOL_BIN: goreleaser
+          TOOL_ARGS: release --snapshot --clean
 
   release-check:
     desc: Validate GoReleaser configuration
     cmds:
       - echo "Validating GoReleaser configuration..."
-      - |
-        GOBIN_DIR="$(go env GOPATH)/bin"
-        echo "Installing GoReleaser..."
-        GOTOOLCHAIN=go1.26.0 go install github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
-        "${GOBIN_DIR}/goreleaser" check
+      - task: _run-go-tool
+        vars:
+          TOOL_NAME: GoReleaser
+          TOOL_PACKAGE: github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
+          TOOL_BIN: goreleaser
+          TOOL_ARGS: check
 
   # Development
   dev-setup:
@@ -245,17 +261,10 @@ tasks:
     cmds:
       - echo "Setting up development environment..."
       - |
-        tools=(
-          "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1"
-          "golang.org/x/tools/cmd/goimports@v0.42.0"
-          "github.com/securego/gosec/v2/cmd/gosec@v2.23.0"
-        )
-        for tool in "${tools[@]}"; do
-          if ! command -v "$(basename ${tool%@*})" >/dev/null 2>&1; then
-            echo "Installing $tool..."
-            GOTOOLCHAIN=go1.26.0 go install "$tool"
-          fi
-        done
+        GOTOOLCHAIN=go1.26.0 go install \
+          github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 \
+          golang.org/x/tools/cmd/goimports@v0.42.0 \
+          github.com/securego/gosec/v2/cmd/gosec@v2.23.0
       - echo "Development environment ready."
 
   # Pre-commit and CI tasks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,6 +12,7 @@ vars:
   GIT_COMMIT:
     sh: git rev-parse --short HEAD 2>/dev/null || echo "unknown"
   BINARY_NAME: cvewatch
+  GORELEASER_VERSION: v2.14.0
 
 tasks:
   default:
@@ -107,11 +108,10 @@ tasks:
       - echo "Formatting code..."
       - go fmt ./...
       - |
-        if ! command -v goimports >/dev/null 2>&1; then
-          echo "Installing goimports..."
-          go install golang.org/x/tools/cmd/goimports@v0.21.0
-        fi
-        goimports -w .
+        GOBIN_DIR="$(go env GOPATH)/bin"
+        echo "Installing goimports..."
+        GOTOOLCHAIN=go1.26.0 go install golang.org/x/tools/cmd/goimports@v0.42.0
+        "${GOBIN_DIR}/goimports" -w .
 
   check-fmt:
     desc: Check if code is properly formatted
@@ -131,12 +131,9 @@ tasks:
       - echo "Running linters..."
       - |
         GOBIN_DIR="$(go env GOPATH)/bin"
-        if ! command -v golangci-lint >/dev/null 2>&1; then
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
-          "${GOBIN_DIR}/golangci-lint" run
-        else
-          golangci-lint run
-        fi
+        echo "Installing golangci-lint..."
+        GOTOOLCHAIN=go1.26.0 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+        "${GOBIN_DIR}/golangci-lint" run
 
   security-scan:
     desc: Run security scanner (gosec)
@@ -144,13 +141,9 @@ tasks:
       - echo "Running security scan..."
       - |
         GOBIN_DIR="$(go env GOPATH)/bin"
-        if command -v gosec >/dev/null 2>&1; then
-          gosec -fmt=json -out=security-report.json -severity=medium -confidence=medium ./...
-        else
-          echo "Installing gosec..."
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
-          "${GOBIN_DIR}/gosec" -fmt=json -out=security-report.json -severity=medium -confidence=medium ./...
-        fi
+        echo "Installing gosec..."
+        GOTOOLCHAIN=go1.26.0 go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
+        "${GOBIN_DIR}/gosec" -fmt=json -out=security-report.json -severity=medium -confidence=medium ./...
       - echo "Security scan completed. Report saved to security-report.json"
 
   vuln-check:
@@ -159,13 +152,9 @@ tasks:
       - echo "Running govulncheck..."
       - |
         GOBIN_DIR="$(go env GOPATH)/bin"
-        if ! command -v govulncheck >/dev/null 2>&1; then
-          echo "Installing govulncheck..."
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          "${GOBIN_DIR}/govulncheck" ./...
-        else
-          govulncheck ./...
-        fi
+        echo "Installing govulncheck..."
+        GOTOOLCHAIN=go1.26.0 go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        "${GOBIN_DIR}/govulncheck" ./...
       - echo "Vulnerability check completed."
 
   # Installation
@@ -219,36 +208,33 @@ tasks:
     desc: Create release with GoReleaser
     cmds:
       - echo "Creating release with GoReleaser..."
-      - |
-        if ! command -v goreleaser >/dev/null 2>&1; then
-          echo "Installing GoReleaser..."
-          go install github.com/goreleaser/goreleaser/v2@latest
-        fi
       - git checkout -- .
       - git clean -fd
-      - goreleaser release --clean
+      - |
+        GOBIN_DIR="$(go env GOPATH)/bin"
+        echo "Installing GoReleaser..."
+        GOTOOLCHAIN=go1.26.0 go install github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
+        "${GOBIN_DIR}/goreleaser" release --clean
 
   release-snapshot:
     desc: Create snapshot release (for testing)
     cmds:
       - echo "Creating snapshot release..."
       - |
-        if ! command -v goreleaser >/dev/null 2>&1; then
-          echo "Installing GoReleaser..."
-          go install github.com/goreleaser/goreleaser/v2@latest
-        fi
-      - goreleaser release --snapshot --clean
+        GOBIN_DIR="$(go env GOPATH)/bin"
+        echo "Installing GoReleaser..."
+        GOTOOLCHAIN=go1.26.0 go install github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
+        "${GOBIN_DIR}/goreleaser" release --snapshot --clean
 
   release-check:
     desc: Validate GoReleaser configuration
     cmds:
       - echo "Validating GoReleaser configuration..."
       - |
-        if ! command -v goreleaser >/dev/null 2>&1; then
-          echo "Installing GoReleaser..."
-          go install github.com/goreleaser/goreleaser/v2@latest
-        fi
-      - goreleaser check
+        GOBIN_DIR="$(go env GOPATH)/bin"
+        echo "Installing GoReleaser..."
+        GOTOOLCHAIN=go1.26.0 go install github.com/goreleaser/goreleaser/v2@{{.GORELEASER_VERSION}}
+        "${GOBIN_DIR}/goreleaser" check
 
   # Development
   dev-setup:
@@ -260,14 +246,14 @@ tasks:
       - echo "Setting up development environment..."
       - |
         tools=(
-          "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"
-          "golang.org/x/tools/cmd/goimports@latest"
-          "github.com/securego/gosec/v2/cmd/gosec@latest"
+          "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1"
+          "golang.org/x/tools/cmd/goimports@v0.42.0"
+          "github.com/securego/gosec/v2/cmd/gosec@v2.23.0"
         )
         for tool in "${tools[@]}"; do
           if ! command -v "$(basename ${tool%@*})" >/dev/null 2>&1; then
             echo "Installing $tool..."
-            go install "$tool"
+            GOTOOLCHAIN=go1.26.0 go install "$tool"
           fi
         done
       - echo "Development environment ready."

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cvewatch
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,32 +174,30 @@ func (cm *ConfigManager) loadFromFile(configFile string) error {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	var config types.AppConfig
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	var parsedConfig types.AppConfig
+	if err := yaml.Unmarshal(data, &parsedConfig); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	if err := cm.validateConfig(&config); err != nil {
-		return fmt.Errorf("config validation failed: %w", err)
-	}
-
-	cm.config = &config
-
-	return nil
+	return cm.assignValidatedConfig(&parsedConfig)
 }
 
 // loadFromViper loads configuration from viper fallback
 func (cm *ConfigManager) loadFromViper() error {
-	var fallbackConfig types.AppConfig
-	if err := cm.viper.Unmarshal(&fallbackConfig); err != nil {
+	var parsedConfig types.AppConfig
+	if err := cm.viper.Unmarshal(&parsedConfig); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	if err := cm.validateConfig(&fallbackConfig); err != nil {
+	return cm.assignValidatedConfig(&parsedConfig)
+}
+
+func (cm *ConfigManager) assignValidatedConfig(config *types.AppConfig) error {
+	if err := cm.validateConfig(config); err != nil {
 		return fmt.Errorf("config validation failed: %w", err)
 	}
 
-	cm.config = &fallbackConfig
+	cm.config = config
 
 	return nil
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -154,15 +154,7 @@ func (o *OutputFormatter) writeSimpleCVE(index int, cve types.CVE) error {
 
 // outputJSON outputs results in JSON format
 func (o *OutputFormatter) outputJSON(result *types.SearchResult) error {
-	output := map[string]interface{}{
-		"search_date":     result.Date,
-		"min_cvss":        result.MinCVSS,
-		"max_cvss":        result.MaxCVSS,
-		"products":        result.Products,
-		"total_found":     result.TotalFound,
-		"query_time":      result.QueryTime,
-		"vulnerabilities": result.CVEs,
-	}
+	output := o.buildStructuredOutput(result)
 
 	if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {
 		return fmt.Errorf("failed to encode JSON output: %w", err)
@@ -173,15 +165,7 @@ func (o *OutputFormatter) outputJSON(result *types.SearchResult) error {
 
 // outputYAML outputs results in YAML format
 func (o *OutputFormatter) outputYAML(result *types.SearchResult) error {
-	output := map[string]interface{}{
-		"search_date":     result.Date,
-		"min_cvss":        result.MinCVSS,
-		"max_cvss":        result.MaxCVSS,
-		"products":        result.Products,
-		"total_found":     result.TotalFound,
-		"query_time":      result.QueryTime,
-		"vulnerabilities": result.CVEs,
-	}
+	output := o.buildStructuredOutput(result)
 
 	if err := yaml.NewEncoder(os.Stdout).Encode(output); err != nil {
 		return fmt.Errorf("failed to encode YAML output: %w", err)
@@ -223,10 +207,7 @@ func (o *OutputFormatter) outputTable(result *types.SearchResult) error {
 		description := o.getEnglishDescription(cve)
 		description = o.truncateString(description, 50)
 
-		reference := ""
-		if len(cve.References) > 0 {
-			reference = cve.References[0].URL
-		}
+		reference := o.firstReferenceURL(cve)
 
 		if _, err := fmt.Fprintf(writer, "%s\t%.1f\t%s\t%s\t%s\t%s\n",
 			cve.ID,
@@ -266,10 +247,7 @@ func (o *OutputFormatter) outputCSV(result *types.SearchResult) error {
 		description := o.getEnglishDescription(cve)
 		affectedProducts := o.getAffectedProducts(cve)
 
-		reference := ""
-		if len(cve.References) > 0 {
-			reference = cve.References[0].URL
-		}
+		reference := o.firstReferenceURL(cve)
 
 		row := []string{
 			cve.ID,
@@ -301,6 +279,26 @@ func (o *OutputFormatter) getCVSSScore(cve types.CVE) float64 {
 	}
 
 	return 0.0
+}
+
+func (o *OutputFormatter) buildStructuredOutput(result *types.SearchResult) map[string]interface{} {
+	return map[string]interface{}{
+		"search_date":     result.Date,
+		"min_cvss":        result.MinCVSS,
+		"max_cvss":        result.MaxCVSS,
+		"products":        result.Products,
+		"total_found":     result.TotalFound,
+		"query_time":      result.QueryTime,
+		"vulnerabilities": result.CVEs,
+	}
+}
+
+func (o *OutputFormatter) firstReferenceURL(cve types.CVE) string {
+	if len(cve.References) == 0 {
+		return ""
+	}
+
+	return cve.References[0].URL
 }
 
 // getSeverity returns the severity level for a CVSS score

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -34,6 +34,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func newTestFormatter() *OutputFormatter {
+	return NewOutputFormatter("simple", &types.AppConfig{})
+}
+
+func newTestFormatterWithTruncateLength(length int) *OutputFormatter {
+	return NewOutputFormatter("simple", &types.AppConfig{
+		Output: types.OutputSettings{TruncateLength: length},
+	})
+}
+
 func TestNewOutputFormatter(t *testing.T) {
 	config := &types.AppConfig{}
 	formatter := NewOutputFormatter("simple", config)
@@ -41,8 +51,7 @@ func TestNewOutputFormatter(t *testing.T) {
 }
 
 func TestGetCVSSScore(t *testing.T) {
-	config := &types.AppConfig{}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatter()
 
 	// Test CVE with CVSS v3.1 score
 	cve := types.CVE{
@@ -84,8 +93,7 @@ func TestGetCVSSScore(t *testing.T) {
 }
 
 func TestGetSeverity(t *testing.T) {
-	config := &types.AppConfig{}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatter()
 
 	assert.Equal(t, "CRITICAL", formatter.getSeverity(9.5))
 	assert.Equal(t, "HIGH", formatter.getSeverity(8.0))
@@ -95,8 +103,7 @@ func TestGetSeverity(t *testing.T) {
 }
 
 func TestGetEnglishDescription(t *testing.T) {
-	config := &types.AppConfig{}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatter()
 
 	// Test CVE with English description
 	cve := types.CVE{
@@ -128,8 +135,7 @@ func TestGetEnglishDescription(t *testing.T) {
 }
 
 func TestExtractProductName(t *testing.T) {
-	config := &types.AppConfig{}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatter()
 
 	// Test valid CPE string
 	cpe := "cpe:2.3:a:microsoft:windows:10:*:*:*:*:*:*:*"
@@ -148,8 +154,7 @@ func TestExtractProductName(t *testing.T) {
 }
 
 func TestTruncateString(t *testing.T) {
-	config := &types.AppConfig{}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatter()
 
 	// Test string shorter than max length
 	result := formatter.truncateString("short", 10)
@@ -173,12 +178,7 @@ func TestTruncateString(t *testing.T) {
 }
 
 func TestGetAffectedProducts(t *testing.T) {
-	config := &types.AppConfig{
-		Output: types.OutputSettings{
-			TruncateLength: 100,
-		},
-	}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatterWithTruncateLength(100)
 
 	// Test CVE with CPE matches
 	cve := types.CVE{
@@ -225,12 +225,7 @@ func TestGetAffectedProducts(t *testing.T) {
 }
 
 func TestGetAffectedProducts_DuplicateRemoval(t *testing.T) {
-	config := &types.AppConfig{
-		Output: types.OutputSettings{
-			TruncateLength: 100,
-		},
-	}
-	formatter := NewOutputFormatter("simple", config)
+	formatter := newTestFormatterWithTruncateLength(100)
 
 	// Test CVE with duplicate CPE matches
 	cve := types.CVE{

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -440,11 +440,20 @@ func (cmds *Commands) validateCVEID(cveID string) error {
 
 // loadInfoConfiguration loads configuration for info command
 func (cmds *Commands) loadInfoConfiguration(configManager *config.ConfigManager) (*types.AppConfig, error) {
+	return cmds.loadExistingConfig(configManager)
+}
+
+func (cmds *Commands) loadExistingConfig(configManager *config.ConfigManager) (*types.AppConfig, error) {
 	if err := configManager.LoadConfig(cmds.getConfigFilePath()); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	return configManager.GetConfig(), nil
+	appConfig := configManager.GetConfig()
+	if appConfig == nil {
+		return nil, fmt.Errorf("configuration is empty or invalid")
+	}
+
+	return appConfig, nil
 }
 
 // fetchCVEDetails fetches CVE details from NVD
@@ -524,11 +533,10 @@ func (cmds *Commands) displayReferences(cve *types.CVE) {
 
 // runConfig executes the config command
 func (cmds *Commands) runConfig(configManager *config.ConfigManager) error {
-	if err := configManager.LoadConfig(cmds.getConfigFilePath()); err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+	config, err := cmds.loadExistingConfig(configManager)
+	if err != nil {
+		return err
 	}
-
-	config := configManager.GetConfig()
 
 	fmt.Printf("CVEWatch Configuration\n")
 	fmt.Printf("=====================\n\n")
@@ -623,16 +631,16 @@ func (cmds *Commands) setDefaultDate(flags *types.CommandLineFlags) {
 }
 
 func (cmds *Commands) validateDateFlags(flags *types.CommandLineFlags) error {
-	if flags.Date != "" && !utils.IsValidDate(flags.Date) {
-		return fmt.Errorf("invalid date format: %s (expected YYYY-MM-DD)", flags.Date)
+	if err := cmds.validateOptionalDate("date", flags.Date); err != nil {
+		return err
 	}
 
-	// Validate start/end date formats
-	if flags.StartDate != "" && !utils.IsValidDate(flags.StartDate) {
-		return fmt.Errorf("invalid start date format: %s (expected YYYY-MM-DD)", flags.StartDate)
+	if err := cmds.validateOptionalDate("start date", flags.StartDate); err != nil {
+		return err
 	}
-	if flags.EndDate != "" && !utils.IsValidDate(flags.EndDate) {
-		return fmt.Errorf("invalid end date format: %s (expected YYYY-MM-DD)", flags.EndDate)
+
+	if err := cmds.validateOptionalDate("end date", flags.EndDate); err != nil {
+		return err
 	}
 
 	// Validate date range
@@ -640,6 +648,14 @@ func (cmds *Commands) validateDateFlags(flags *types.CommandLineFlags) error {
 		if !utils.IsValidDateRange(flags.StartDate, flags.EndDate) {
 			return fmt.Errorf("invalid date range: start date must be before or equal to end date")
 		}
+	}
+
+	return nil
+}
+
+func (cmds *Commands) validateOptionalDate(label, date string) error {
+	if date != "" && !utils.IsValidDate(date) {
+		return fmt.Errorf("invalid %s format: %s (expected YYYY-MM-DD)", label, date)
 	}
 
 	return nil
@@ -673,11 +689,10 @@ func (cmds *Commands) runHealth(configManager *config.ConfigManager) error {
 
 	fmt.Println("🏥 Checking NVD API health...")
 
-	if err := configManager.LoadConfig(cmds.getConfigFilePath()); err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+	config, err := cmds.loadExistingConfig(configManager)
+	if err != nil {
+		return err
 	}
-
-	config := configManager.GetConfig()
 	apiKey := viper.GetString("api-key")
 	nvdClient := nvd.NewNVDClient(config, configManager, apiKey)
 
@@ -780,13 +795,9 @@ func (cmds *Commands) runWatchIteration(ctx context.Context, config *types.AppCo
 
 // runCache executes cache management operations
 func (cmds *Commands) runCache(configManager *config.ConfigManager, clean bool) error {
-	if err := configManager.LoadConfig(cmds.getConfigFilePath()); err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	appConfig := configManager.GetConfig()
-	if appConfig == nil {
-		return fmt.Errorf("configuration is empty or invalid")
+	appConfig, err := cmds.loadExistingConfig(configManager)
+	if err != nil {
+		return err
 	}
 
 	if !appConfig.Cache.Enabled {

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -38,6 +38,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newBaseTestAppConfig() *types.AppConfig {
+	return &types.AppConfig{
+		App: types.AppSettings{
+			Name:    "CVEWatch",
+			Version: "2.0.0",
+		},
+		NVD: types.NVDSettings{
+			BaseURL:       "https://services.nvd.nist.gov/rest/json/cves/2.0",
+			RateLimit:     1000,
+			Timeout:       30,
+			RetryAttempts: 3,
+			RetryDelay:    5,
+		},
+		Search: types.SearchSettings{
+			DefaultMinCVSS:    0.0,
+			DefaultMaxCVSS:    10.0,
+			DefaultMaxResults: 100,
+		},
+		Output: types.OutputSettings{
+			DefaultFormat: "simple",
+			Formats:       []string{"simple", "json", "yaml", "table", "csv"},
+		},
+		Products: []types.Product{{Name: "Linux Kernel"}},
+	}
+}
+
+func newDefaultsOverrideConfig() *types.AppConfig {
+	return &types.AppConfig{
+		Search: types.SearchSettings{
+			DefaultMinCVSS:    5.0,
+			DefaultMaxCVSS:    9.0,
+			DefaultMaxResults: 50,
+		},
+		Output: types.OutputSettings{
+			DefaultFormat: "table",
+		},
+	}
+}
+
 func TestNewCommands(t *testing.T) {
 	configManager := config.NewConfigManager()
 	cmds := NewCommands(configManager)
@@ -123,16 +162,7 @@ func TestLoadAndOverrideFlagsWithDefaults(t *testing.T) {
 	configManager := config.NewConfigManager()
 
 	// Create a test config
-	testConfig := &types.AppConfig{
-		Search: types.SearchSettings{
-			DefaultMinCVSS:    5.0,
-			DefaultMaxCVSS:    9.0,
-			DefaultMaxResults: 50,
-		},
-		Output: types.OutputSettings{
-			DefaultFormat: "table",
-		},
-	}
+	testConfig := newDefaultsOverrideConfig()
 
 	configManager.SetConfig(testConfig)
 	cmds := NewCommands(configManager)
@@ -191,12 +221,8 @@ func TestValidateOutputFormat(t *testing.T) {
 
 func TestCreateSearchRequest(t *testing.T) {
 	configManager := config.NewConfigManager()
-	testConfig := &types.AppConfig{
-		Products: []types.Product{
-			{Name: "Linux Kernel"},
-			{Name: "OpenSSL"},
-		},
-	}
+	testConfig := newBaseTestAppConfig()
+	testConfig.Products = []types.Product{{Name: "Linux Kernel"}, {Name: "OpenSSL"}}
 	cmds := NewCommands(configManager)
 
 	flags := &types.CommandLineFlags{
@@ -256,31 +282,7 @@ func TestDisplaySearchParameters(t *testing.T) {
 
 func TestRunSearch(t *testing.T) {
 	configManager := config.NewConfigManager()
-	testConfig := &types.AppConfig{
-		App: types.AppSettings{
-			Name:    "CVEWatch",
-			Version: "2.0.0",
-		},
-		NVD: types.NVDSettings{
-			BaseURL:       "https://services.nvd.nist.gov/rest/json/cves/2.0",
-			RateLimit:     1000,
-			Timeout:       30,
-			RetryAttempts: 3,
-			RetryDelay:    5,
-		},
-		Search: types.SearchSettings{
-			DefaultMinCVSS:    0.0,
-			DefaultMaxCVSS:    10.0,
-			DefaultMaxResults: 100,
-		},
-		Output: types.OutputSettings{
-			DefaultFormat: "simple",
-			Formats:       []string{"simple", "json", "yaml", "table", "csv"},
-		},
-		Products: []types.Product{
-			{Name: "Linux Kernel"},
-		},
-	}
+	testConfig := newBaseTestAppConfig()
 	configManager.SetConfig(testConfig)
 
 	cmds := NewCommands(configManager)
@@ -299,19 +301,7 @@ func TestRunSearch(t *testing.T) {
 
 func TestRunInfo(t *testing.T) {
 	configManager := config.NewConfigManager()
-	testConfig := &types.AppConfig{
-		App: types.AppSettings{
-			Name:    "CVEWatch",
-			Version: "2.0.0",
-		},
-		NVD: types.NVDSettings{
-			BaseURL:       "https://services.nvd.nist.gov/rest/json/cves/2.0",
-			RateLimit:     1000,
-			Timeout:       30,
-			RetryAttempts: 3,
-			RetryDelay:    5,
-		},
-	}
+	testConfig := newBaseTestAppConfig()
 	configManager.SetConfig(testConfig)
 
 	cmds := NewCommands(configManager)
@@ -327,35 +317,14 @@ func TestRunInfo(t *testing.T) {
 
 func TestRunConfig(t *testing.T) {
 	configManager := config.NewConfigManager()
-	testConfig := &types.AppConfig{
-		App: types.AppSettings{
-			Name:    "CVEWatch",
-			Version: "2.0.0",
-		},
-		NVD: types.NVDSettings{
-			BaseURL:       "https://services.nvd.nist.gov/rest/json/cves/2.0",
-			RateLimit:     1000,
-			Timeout:       30,
-			RetryAttempts: 3,
-			RetryDelay:    5,
-		},
-		Search: types.SearchSettings{
-			DefaultMinCVSS:    0.0,
-			DefaultMaxCVSS:    10.0,
-			DefaultMaxResults: 100,
-		},
-		Output: types.OutputSettings{
-			DefaultFormat: "simple",
-			Formats:       []string{"simple", "json", "yaml", "table", "csv"},
-		},
-		Products: []types.Product{
-			{
-				Name:        "Linux Kernel",
-				Keywords:    []string{"linux", "kernel"},
-				CPEPatterns: []string{"cpe:2.3:o:*:linux:*:*:*:*:*:*:*"},
-				Description: "Linux operating system kernel",
-				Priority:    "high",
-			},
+	testConfig := newBaseTestAppConfig()
+	testConfig.Products = []types.Product{
+		{
+			Name:        "Linux Kernel",
+			Keywords:    []string{"linux", "kernel"},
+			CPEPatterns: []string{"cpe:2.3:o:*:linux:*:*:*:*:*:*:*"},
+			Description: "Linux operating system kernel",
+			Priority:    "high",
 		},
 	}
 	configManager.SetConfig(testConfig)
@@ -382,11 +351,7 @@ func TestRunVersion(t *testing.T) {
 
 func TestLoadConfiguration(t *testing.T) {
 	configManager := config.NewConfigManager()
-	testConfig := &types.AppConfig{
-		App: types.AppSettings{
-			Name: "CVEWatch",
-		},
-	}
+	testConfig := newBaseTestAppConfig()
 	configManager.SetConfig(testConfig)
 
 	cmds := NewCommands(configManager)
@@ -400,16 +365,7 @@ func TestLoadConfiguration(t *testing.T) {
 
 func TestLoadAndOverrideFlags(t *testing.T) {
 	configManager := config.NewConfigManager()
-	testConfig := &types.AppConfig{
-		Search: types.SearchSettings{
-			DefaultMinCVSS:    5.0,
-			DefaultMaxCVSS:    9.0,
-			DefaultMaxResults: 50,
-		},
-		Output: types.OutputSettings{
-			DefaultFormat: "table",
-		},
-	}
+	testConfig := newDefaultsOverrideConfig()
 	configManager.SetConfig(testConfig)
 
 	cmds := NewCommands(configManager)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -94,49 +94,51 @@ func (e *CVEWatchError) WithContext(key string, value interface{}) *CVEWatchErro
 	return e
 }
 
-// NewNetworkError creates a new network-related error
-func NewNetworkError(message string, cause error) *CVEWatchError {
+func newError(errorType ErrorType, message string, cause error) *CVEWatchError {
 	return &CVEWatchError{
-		Type:    ErrorTypeNetwork,
+		Type:    errorType,
 		Message: message,
 		Cause:   cause,
 	}
+}
+
+func asCVEWatchError(err error) (*CVEWatchError, bool) {
+	var cveErr *CVEWatchError
+	if errors.As(err, &cveErr) {
+		return cveErr, true
+	}
+
+	return nil, false
+}
+
+func isErrorType(err error, expectedType ErrorType) bool {
+	cveErr, ok := asCVEWatchError(err)
+	return ok && cveErr.Type == expectedType
+}
+
+// NewNetworkError creates a new network-related error
+func NewNetworkError(message string, cause error) *CVEWatchError {
+	return newError(ErrorTypeNetwork, message, cause)
 }
 
 // NewValidationError creates a new validation-related error
 func NewValidationError(message string, cause error) *CVEWatchError {
-	return &CVEWatchError{
-		Type:    ErrorTypeValidation,
-		Message: message,
-		Cause:   cause,
-	}
+	return newError(ErrorTypeValidation, message, cause)
 }
 
 // NewConfigurationError creates a new configuration-related error
 func NewConfigurationError(message string, cause error) *CVEWatchError {
-	return &CVEWatchError{
-		Type:    ErrorTypeConfiguration,
-		Message: message,
-		Cause:   cause,
-	}
+	return newError(ErrorTypeConfiguration, message, cause)
 }
 
 // NewAPIError creates a new API-related error
 func NewAPIError(message string, cause error) *CVEWatchError {
-	return &CVEWatchError{
-		Type:    ErrorTypeAPI,
-		Message: message,
-		Cause:   cause,
-	}
+	return newError(ErrorTypeAPI, message, cause)
 }
 
 // NewParsingError creates a new parsing-related error
 func NewParsingError(message string, cause error) *CVEWatchError {
-	return &CVEWatchError{
-		Type:    ErrorTypeParsing,
-		Message: message,
-		Cause:   cause,
-	}
+	return newError(ErrorTypeParsing, message, cause)
 }
 
 // NewRateLimitError creates a new rate limiting error
@@ -192,53 +194,32 @@ func NewHTTPError(resp *http.Response, cause error) *CVEWatchError {
 
 // IsNetworkError checks if an error is a network-related error
 func IsNetworkError(err error) bool {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
-		return cveErr.Type == ErrorTypeNetwork
-	}
-	return false
+	return isErrorType(err, ErrorTypeNetwork)
 }
 
 // IsRateLimitError checks if an error is a rate limiting error
 func IsRateLimitError(err error) bool {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
-		return cveErr.Type == ErrorTypeRateLimit
-	}
-	return false
+	return isErrorType(err, ErrorTypeRateLimit)
 }
 
 // IsValidationError checks if an error is a validation error
 func IsValidationError(err error) bool {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
-		return cveErr.Type == ErrorTypeValidation
-	}
-	return false
+	return isErrorType(err, ErrorTypeValidation)
 }
 
 // IsConfigurationError checks if an error is a configuration error
 func IsConfigurationError(err error) bool {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
-		return cveErr.Type == ErrorTypeConfiguration
-	}
-	return false
+	return isErrorType(err, ErrorTypeConfiguration)
 }
 
 // IsNotFoundError checks if an error is a not found error
 func IsNotFoundError(err error) bool {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
-		return cveErr.Type == ErrorTypeNotFound
-	}
-	return false
+	return isErrorType(err, ErrorTypeNotFound)
 }
 
 // FormatError formats an error with user-friendly output
 func FormatError(err error) string {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
+	if cveErr, ok := asCVEWatchError(err); ok {
 		var builder strings.Builder
 
 		// Main error message
@@ -280,8 +261,7 @@ func WrapError(err error, message string) *CVEWatchError {
 
 // GetErrorType returns the type of error
 func GetErrorType(err error) ErrorType {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
+	if cveErr, ok := asCVEWatchError(err); ok {
 		return cveErr.Type
 	}
 	return ErrorTypeUnknown
@@ -289,8 +269,7 @@ func GetErrorType(err error) ErrorType {
 
 // GetErrorCode returns the error code if available
 func GetErrorCode(err error) string {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
+	if cveErr, ok := asCVEWatchError(err); ok {
 		return cveErr.Code
 	}
 	return ""
@@ -298,8 +277,7 @@ func GetErrorCode(err error) string {
 
 // GetErrorSuggestion returns the suggestion if available
 func GetErrorSuggestion(err error) string {
-	var cveErr *CVEWatchError
-	if errors.As(err, &cveErr) {
+	if cveErr, ok := asCVEWatchError(err); ok {
 		return cveErr.Suggestion
 	}
 	return ""

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -242,24 +242,24 @@ func FormatError(err error) string {
 		var builder strings.Builder
 
 		// Main error message
-		builder.WriteString(fmt.Sprintf("❌ Error: %s\n", cveErr.Message))
+		fmt.Fprintf(&builder, "❌ Error: %s\n", cveErr.Message)
 
 		// Add suggestion if available
 		if cveErr.Suggestion != "" {
-			builder.WriteString(fmt.Sprintf("💡 Suggestion: %s\n", cveErr.Suggestion))
+			fmt.Fprintf(&builder, "💡 Suggestion: %s\n", cveErr.Suggestion)
 		}
 
 		// Add context information
 		if len(cveErr.Context) > 0 {
 			builder.WriteString("📋 Context:\n")
 			for key, value := range cveErr.Context {
-				builder.WriteString(fmt.Sprintf("   %s: %v\n", key, value))
+				fmt.Fprintf(&builder, "   %s: %v\n", key, value)
 			}
 		}
 
 		// Add underlying error
 		if cveErr.Cause != nil {
-			builder.WriteString(fmt.Sprintf("🔍 Details: %v\n", cveErr.Cause))
+			fmt.Fprintf(&builder, "🔍 Details: %v\n", cveErr.Cause)
 		}
 
 		return builder.String()


### PR DESCRIPTION
## Summary
- Upgrade project Go directive to `1.26.0`
- Update CI workflow pins to latest stable tool versions
  - Go `1.26.0`
  - GoReleaser `v2.14.0`
  - Task `v3.48.0`
- Refresh Taskfile tool pins
  - golangci-lint `v2.10.1`
  - gosec `v2.23.0`
  - govulncheck `v1.1.4`
  - goimports `v0.42.0`
- Ensure task execution uses pinned binaries installed via Go 1.26 toolchain to avoid stale global binaries
- Align lint config and docs with Go 1.26 baseline
- Fix `staticcheck` findings in `pkg/errors/errors.go`

## Validation
- `go mod tidy && go mod verify`
- `task ci-quality`
- `task ci-test`
- `task ci-build`
- `task release-check`

All checks pass locally after these updates.